### PR TITLE
Palavras-chave em documentos

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,7 @@ model Document {
   title String
   description String
   fileUrl String
+  keywords String[]
 
   lawyer Lawyer @relation(fields: [lawyerId], references: [id])
   lawyerId String @db.ObjectId

--- a/src/core/mappers/documents.ts
+++ b/src/core/mappers/documents.ts
@@ -6,6 +6,7 @@ interface DocumentObject {
   title: string;
   description: string;
   fileUrl: string;
+  keywords: string[];
   lawyerId: string;
   createdAt: Date;
   updatedAt: Date;
@@ -17,6 +18,7 @@ export class DocumentsMapper {
     title,
     description,
     fileUrl,
+    keywords,
     lawyerId,
     createdAt,
     updatedAt,
@@ -26,6 +28,7 @@ export class DocumentsMapper {
         title,
         description,
         fileUrl,
+        keywords,
         lawyerId: new UniqueId(lawyerId),
         createdAt,
         updatedAt,
@@ -40,6 +43,7 @@ export class DocumentsMapper {
       title: document.title,
       description: document.description,
       fileUrl: document.fileUrl,
+      keywords: document.keywords,
       lawyerId: document.lawyerId.value,
       createdAt: document.createdAt,
       updatedAt: document.updatedAt,

--- a/src/domain/documents/entities/document.ts
+++ b/src/domain/documents/entities/document.ts
@@ -5,6 +5,7 @@ export interface DocumentProps {
   title: string;
   description: string;
   fileUrl: string;
+  keywords: string[];
   lawyerId: UniqueId;
   createdAt?: Date;
   updatedAt?: Date;
@@ -21,6 +22,10 @@ export class Document extends Entity<DocumentProps> {
 
   get fileUrl() {
     return this.props.fileUrl;
+  }
+
+  get keywords() {
+    return this.props.keywords;
   }
 
   get lawyerId() {

--- a/src/domain/documents/use-cases/create-document.ts
+++ b/src/domain/documents/use-cases/create-document.ts
@@ -9,6 +9,7 @@ interface CreateDocumentUseCaseRequest {
   title: string;
   description: string;
   fileUrl: string;
+  keywords: string[];
   lawyerId: string;
 }
 
@@ -29,6 +30,7 @@ export class CreateDocumentUseCase {
     title,
     description,
     fileUrl,
+    keywords,
     lawyerId,
   }: CreateDocumentUseCaseRequest): Promise<CreateDocumentUseCaseResponse> {
     await this.checkLawyerExistence(lawyerId);
@@ -37,6 +39,7 @@ export class CreateDocumentUseCase {
       title,
       description,
       fileUrl,
+      keywords,
       lawyerId: new UniqueId(lawyerId),
     });
 

--- a/src/domain/documents/use-cases/update-document.ts
+++ b/src/domain/documents/use-cases/update-document.ts
@@ -10,6 +10,7 @@ interface UpdateDocumentUseCaseRequest {
   title: string;
   description: string;
   fileUrl: string;
+  keywords: string[];
   lawyerId: string;
 }
 
@@ -31,6 +32,7 @@ export class UpdateDocumentUseCase {
     title,
     description,
     fileUrl,
+    keywords,
     lawyerId,
   }: UpdateDocumentUseCaseRequest): Promise<UpdateDocumentUseCaseResponse> {
     await this.checkLawyerExistence(lawyerId);
@@ -40,6 +42,7 @@ export class UpdateDocumentUseCase {
         title,
         description,
         fileUrl,
+        keywords,
         lawyerId: new UniqueId(lawyerId),
       },
       new UniqueId(id)

--- a/src/infra/database/repositories/prisma-documents.ts
+++ b/src/infra/database/repositories/prisma-documents.ts
@@ -37,6 +37,7 @@ export class PrismaDocumentsRepository implements DocumentsRepository {
         title: document.title,
         description: document.description,
         fileUrl: document.fileUrl,
+        keywords: document.keywords,
         lawyerId: document.lawyerId.value,
       },
     });
@@ -51,6 +52,7 @@ export class PrismaDocumentsRepository implements DocumentsRepository {
         title: document.title,
         description: document.description,
         fileUrl: document.fileUrl,
+        keywords: document.keywords,
         lawyerId: document.lawyerId.value,
       },
     });

--- a/src/infra/http/controllers/documents/create.ts
+++ b/src/infra/http/controllers/documents/create.ts
@@ -10,6 +10,7 @@ const createDocumentsBodySchema = z.object({
   title: z.string(),
   description: z.string(),
   fileUrl: z.string().url(),
+  keywords: z.array(z.string()),
 });
 
 @injectable()
@@ -22,14 +23,14 @@ export class CreateDocumentController {
   async handle(request: Request, response: Response, next: NextFunction) {
     try {
       const { id: lawyerId } = requestUserSchema.parse(request.user);
-      const { title, description, fileUrl } = createDocumentsBodySchema.parse(
-        request.body
-      );
+      const { title, description, fileUrl, keywords } =
+        createDocumentsBodySchema.parse(request.body);
 
       const { document } = await this.createDocumentUseCase.execute({
         title,
         description,
         fileUrl,
+        keywords,
         lawyerId,
       });
 

--- a/src/infra/http/controllers/documents/update.ts
+++ b/src/infra/http/controllers/documents/update.ts
@@ -13,6 +13,7 @@ const updateDocumentsBodySchema = z.object({
   title: z.string(),
   description: z.string(),
   fileUrl: z.string().url(),
+  keywords: z.array(z.string()),
 });
 
 @injectable()
@@ -26,15 +27,15 @@ export class UpdateDocumentController {
     try {
       const { documentId } = updateDocumentsParamsSchema.parse(request.params);
       const { id: lawyerId } = requestUserSchema.parse(request.user);
-      const { title, description, fileUrl } = updateDocumentsBodySchema.parse(
-        request.body
-      );
+      const { title, description, fileUrl, keywords } =
+        updateDocumentsBodySchema.parse(request.body);
 
       const { document } = await this.updateDocumentUseCase.execute({
         id: documentId,
         title,
         description,
         fileUrl,
+        keywords,
         lawyerId,
       });
 

--- a/tests/factories/documents/entities/make-document.ts
+++ b/tests/factories/documents/entities/make-document.ts
@@ -8,6 +8,7 @@ export function makeDocument(override?: Partial<DocumentProps>, id?: UniqueId) {
       title: faker.lorem.words(),
       description: faker.lorem.sentences(),
       fileUrl: faker.internet.url(),
+      keywords: [faker.lorem.word(), faker.lorem.word()],
       lawyerId: new UniqueId(),
       createdAt: faker.date.past(),
       updatedAt: faker.date.recent(),

--- a/tests/unit/core/mappers/documents.spec.ts
+++ b/tests/unit/core/mappers/documents.spec.ts
@@ -9,6 +9,7 @@ describe('DocumentsMapper', () => {
     title: documentMock.title,
     description: documentMock.description,
     fileUrl: documentMock.fileUrl,
+    keywords: documentMock.keywords,
     lawyerId: documentMock.lawyerId.value,
     createdAt: documentMock.createdAt,
     updatedAt: documentMock.updatedAt,

--- a/tests/unit/domain/documents/use-cases/create-document.spec.ts
+++ b/tests/unit/domain/documents/use-cases/create-document.spec.ts
@@ -33,6 +33,7 @@ describe('CreateDocumentUseCase', () => {
         title: documentMock.title,
         description: documentMock.description,
         fileUrl: documentMock.fileUrl,
+        keywords: documentMock.keywords,
         lawyerId: documentMock.lawyerId.value,
       });
 
@@ -52,6 +53,7 @@ describe('CreateDocumentUseCase', () => {
             title: documentMock.title,
             description: documentMock.description,
             fileUrl: documentMock.fileUrl,
+            keywords: documentMock.keywords,
             lawyerId: documentMock.lawyerId.value,
           })
       ).rejects.toThrowError(LawyerNotFoundError);


### PR DESCRIPTION
Este PR irá adicionar os seguintes recursos na codebase:
- palavras-chave no CRUD de documentos:
  - as palavras-chave foram definidas como um atributo de tipo array na entidade de documentos