### PR TITLE
Refatoração para utilizar polimorfismo na manipulação de erros

### DIFF
--- a/src/core/errors/bad-request.ts
+++ b/src/core/errors/bad-request.ts
@@ -1,0 +1,1 @@
+export class BadRequestError extends Error {}

--- a/src/core/errors/lawyer-not-found.ts
+++ b/src/core/errors/lawyer-not-found.ts
@@ -1,4 +1,6 @@
-export class LawyerNotFoundError extends Error {
+import { NotFoundError } from './not-found';
+
+export class LawyerNotFoundError extends NotFoundError {
   constructor(lawyerId: string) {
     super(`Lawyer with id ${lawyerId} was not found`);
   }

--- a/src/core/errors/not-found.ts
+++ b/src/core/errors/not-found.ts
@@ -1,0 +1,1 @@
+export class NotFoundError extends Error {}

--- a/src/core/errors/unauthorized.ts
+++ b/src/core/errors/unauthorized.ts
@@ -1,0 +1,1 @@
+export class UnauthorizedError extends Error {}

--- a/src/core/errors/unprocessable-entity.ts
+++ b/src/core/errors/unprocessable-entity.ts
@@ -1,0 +1,1 @@
+export class UnprocessableEntityError extends Error {}

--- a/src/domain/auth/errors/bad-credentials.ts
+++ b/src/domain/auth/errors/bad-credentials.ts
@@ -1,4 +1,6 @@
-export class BadCredentialsError extends Error {
+import { UnauthorizedError } from '@/core/errors/unauthorized';
+
+export class BadCredentialsError extends UnauthorizedError {
   constructor() {
     super('The credentials provided are wrong');
   }

--- a/src/domain/auth/errors/invalid-token.ts
+++ b/src/domain/auth/errors/invalid-token.ts
@@ -1,4 +1,6 @@
-export class InvalidTokenError extends Error {
+import { UnauthorizedError } from '@/core/errors/unauthorized';
+
+export class InvalidTokenError extends UnauthorizedError {
   constructor() {
     super('The token provided is expired');
   }

--- a/src/domain/auth/errors/lawyer-already-exists.ts
+++ b/src/domain/auth/errors/lawyer-already-exists.ts
@@ -1,4 +1,6 @@
-export class LawyerAlreadyExistsError extends Error {
+import { UnauthorizedError } from '@/core/errors/unauthorized';
+
+export class LawyerAlreadyExistsError extends UnauthorizedError {
   constructor(email: string) {
     super(`A lawyer with email ${email} already exists`);
   }

--- a/src/domain/documents/errors/delete-document-file.ts
+++ b/src/domain/documents/errors/delete-document-file.ts
@@ -1,4 +1,6 @@
-export class DeleteDocumentFileError extends Error {
+import { UnprocessableEntityError } from '@/core/errors/unprocessable-entity';
+
+export class DeleteDocumentFileError extends UnprocessableEntityError {
   constructor() {
     super('Was not possible to delete document file');
   }

--- a/src/domain/documents/errors/document-not-found.ts
+++ b/src/domain/documents/errors/document-not-found.ts
@@ -1,4 +1,6 @@
-export class DocumentNotFoundError extends Error {
+import { NotFoundError } from '@/core/errors/not-found';
+
+export class DocumentNotFoundError extends NotFoundError {
   constructor(documentId: string) {
     super(`Document with id ${documentId} was not found`);
   }

--- a/src/domain/documents/errors/document-owner.ts
+++ b/src/domain/documents/errors/document-owner.ts
@@ -1,4 +1,6 @@
-export class DocumentOwnerError extends Error {
+import { BadRequestError } from '@/core/errors/bad-request';
+
+export class DocumentOwnerError extends BadRequestError {
   constructor(documentId: string, lawyerId: string) {
     super(
       `The lawyer with id ${lawyerId} is not the document with id ${documentId} owner`

--- a/src/domain/documents/errors/invalid-document-extension.ts
+++ b/src/domain/documents/errors/invalid-document-extension.ts
@@ -1,4 +1,6 @@
-export class InvalidDocumentExtension extends Error {
+import { UnprocessableEntityError } from '@/core/errors/unprocessable-entity';
+
+export class InvalidDocumentExtension extends UnprocessableEntityError {
   constructor(fileName: string) {
     super(`The file ${fileName} extension is invalid`);
   }

--- a/src/infra/middlewares/catch-all-errors.ts
+++ b/src/infra/middlewares/catch-all-errors.ts
@@ -1,15 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { HTTP_STATUS } from '../http/statuses';
-import { BadCredentialsError } from '@/domain/auth/errors/bad-credentials';
-import { LawyerAlreadyExistsError } from '@/domain/auth/errors/lawyer-already-exists';
-import { DocumentNotFoundError } from '@/domain/documents/errors/document-not-found';
-import { DocumentOwnerError } from '@/domain/documents/errors/document-owner';
-import { LawyerNotFoundError } from '@/core/errors/lawyer-not-found';
 import { NextFunction, Request, Response } from 'express';
-import { InvalidDocumentExtension } from '@/domain/documents/errors/invalid-document-extension';
-import { DeleteDocumentFileError } from '@/domain/documents/errors/delete-document-file';
-import { InvalidTokenError } from '@/domain/auth/errors/invalid-token';
+import { UnauthorizedError } from '@/core/errors/unauthorized';
+import { NotFoundError } from '@/core/errors/not-found';
+import { BadRequestError } from '@/core/errors/bad-request';
+import { UnprocessableEntityError } from '@/core/errors/unprocessable-entity';
 
 export function catchAllErrors(
   error: any,
@@ -17,35 +13,25 @@ export function catchAllErrors(
   response: Response,
   next: NextFunction
 ) {
-  if (error instanceof DocumentOwnerError) {
+  if (error instanceof BadRequestError) {
     return response
       .status(HTTP_STATUS.BAD_REQUEST)
       .json({ message: error.message });
   }
 
-  if (
-    error instanceof LawyerAlreadyExistsError ||
-    error instanceof BadCredentialsError ||
-    error instanceof InvalidTokenError
-  ) {
+  if (error instanceof UnauthorizedError) {
     return response
       .status(HTTP_STATUS.UNAUTHORIZED)
       .json({ message: error.message });
   }
 
-  if (
-    error instanceof LawyerNotFoundError ||
-    error instanceof DocumentNotFoundError
-  ) {
+  if (error instanceof NotFoundError) {
     return response
       .status(HTTP_STATUS.NOT_FOUND)
       .json({ message: error.message });
   }
 
-  if (
-    error instanceof InvalidDocumentExtension ||
-    error instanceof DeleteDocumentFileError
-  ) {
+  if (error instanceof UnprocessableEntityError) {
     return response
       .status(HTTP_STATUS.UNPROCESSABLE_ENTITY)
       .json({ message: error.message });


### PR DESCRIPTION
Durante o desenvolvimento foi visto que para adicionar uma tratativa de erro era necessário adicionar o erro diretamente. Com o passar do tempo iria ficar um arquivo muito grande com diversas comparações lógicas.

Pensando nisso, foram criadas classes para cada erro mais geral e adicionando herança nos erros previamente criados. Com isso foi possível utilizar polimorfismo na manipulação de erros.