### PR TITLE
Mover pasta middlewares para pasta HTTP dentro da camada de Infra

### DIFF
--- a/src/infra/app.ts
+++ b/src/infra/app.ts
@@ -4,8 +4,8 @@ import express from 'express';
 import { AddressInfo } from 'net';
 import { envSchema } from './env/schema';
 import { routes } from './routes';
-import { catchAllErrors } from './middlewares/catch-all-errors';
-import { authorization } from './middlewares/authorization';
+import { catchAllErrors } from './http/middlewares/catch-all-errors';
+import { authorization } from './http/middlewares/authorization';
 
 export const app = express();
 

--- a/src/infra/http/middlewares/authorization.ts
+++ b/src/infra/http/middlewares/authorization.ts
@@ -1,4 +1,4 @@
-import { HTTP_STATUS } from '../http/statuses';
+import { HTTP_STATUS } from '../statuses';
 import { ValidTokenVerifier } from '@/domain/auth/providers/valid-token-verifier';
 import { NextFunction, Request, Response } from 'express';
 import { container } from 'tsyringe';

--- a/src/infra/http/middlewares/catch-all-errors.ts
+++ b/src/infra/http/middlewares/catch-all-errors.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { HTTP_STATUS } from '../http/statuses';
+import { HTTP_STATUS } from '../statuses';
 import { NextFunction, Request, Response } from 'express';
 import { UnauthorizedError } from '@/core/errors/unauthorized';
 import { NotFoundError } from '@/core/errors/not-found';

--- a/src/infra/http/middlewares/file-upload.ts
+++ b/src/infra/http/middlewares/file-upload.ts
@@ -6,7 +6,7 @@ import { InvalidDocumentExtension } from '@/domain/documents/errors/invalid-docu
 
 const storage = multer.diskStorage({
   destination: (request, file, callback) => {
-    const uploadPath = path.join(__dirname, '../../../uploads');
+    const uploadPath = path.join(__dirname, '../../../../uploads');
     fs.mkdirSync(uploadPath, { recursive: true });
     callback(null, uploadPath);
   },

--- a/src/infra/routes/documents.ts
+++ b/src/infra/routes/documents.ts
@@ -6,7 +6,7 @@ import { FetchDocumentByIdController } from '../http/controllers/documents/fetch
 import { FetchLawyerDocumentsController } from '../http/controllers/documents/fetch-by-lawyer';
 import { UpdateDocumentController } from '../http/controllers/documents/update';
 import { UploadDocumentController } from '../http/controllers/documents/upload';
-import { fileUpload } from '../middlewares/file-upload';
+import { fileUpload } from '../http/middlewares/file-upload';
 import path from 'path';
 import { FetchDocumentHistoryController } from '../http/controllers/documents/fetch-history';
 


### PR DESCRIPTION
Durante o desenvolvimento viu-se que fazia mais sentido a pasta `middlewares` estar dentro da pasta `http` na camada de `infra`. Este PR faz as alterações necessárias.